### PR TITLE
PENG-2460 modify the *publish_image* function to create the ECR repository if it is not found

### DIFF
--- a/builder/subapps/helpers.py
+++ b/builder/subapps/helpers.py
@@ -170,11 +170,9 @@ async def publish_image(
                 repositoryName=image_name,
             )
         except ecr.exceptions.RepositoryNotFoundException:
-            raise Abort(
-                f"There is no repository for {image_name=}",
-                subject="Publish failed",
-                log_message=f"There is no repository for {image_name=}",
-            )
+            logger.warning(f"Repository {image_name} not found. Creating it")
+            if not dry_run:
+                ecr.create_repository(repositoryName=image_name)
 
         logger.debug("Logging into the ECR Public registry via Apptainer")
         command = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vantage-jobs-catalog"
-version = "0.1.0"
+version = "0.1.1"
 description = "Vantage Jobs Catalog"
 authors = ["Omnivector Solutions <info@omnivector.solutions>"]
 readme = "README.md"


### PR DESCRIPTION
#### What
This PR modifies the *publish_image* image used by the `apptainer` subcommand in a way that, when the remote ECR repository doesn't exist, it will create a new one (if `--dry-run` is not passed)

#### Why
This is needed to make added job scripts to integrate easier with the CI/CD pipeline.