### PR TITLE
fix the motorbike job script to be compatible with OpenFOAM 11

### DIFF
--- a/cfd-openfoam-motorbike/Dockerfile
+++ b/cfd-openfoam-motorbike/Dockerfile
@@ -13,6 +13,9 @@ RUN apt install -y openfoam11
 
 RUN bash -c "source /opt/openfoam11/etc/bashrc"
 
+RUN mkdir -p /.singularity.d/env/
+RUN echo ". /opt/openfoam11/etc/bashrc" >> /.singularity.d/env/91-environment.sh
+
 EXPOSE 8080
 
 CMD ["/bin/bash"]

--- a/cfd-openfoam-motorbike/README.md
+++ b/cfd-openfoam-motorbike/README.md
@@ -1,28 +1,33 @@
-# Motorbike Simulation with OpenFOAM
+# Motorbike Aerodynamic Simulation with OpenFOAM
 
-This job script performs an aerodynamic simulation of a motorbike using OpenFOAM, an open-source
-computational fluid dynamics (CFD) software package. It leverages Apptainer (formerly Singularity)
-to encapsulate the OpenFOAM environment and ensure reproducibility.
+This job script performs an aerodynamic simulation of a motorbike using OpenFOAM, an open-source Computational
+Fluid Dynamics (CFD) software package. It leverages Apptainer to encapsulate the OpenFOAM environment, ensuring
+reproducibility and simplifying execution on HPC clusters.
 
 ## Simulation Steps
 
-The script performs the following steps:
+The script orchestrates the following steps:
 
-1. **Clone OpenFOAM**: Clones the OpenFOAM-11 source code from GitHub if it's not already available.
-2. **Create Working Directory**: Creates a unique working directory within the shared NFS filesystem.
-3. **Fetch Apptainer Image**: Downloads the OpenFOAM Apptainer image from an S3 bucket if it doesn't exist.
-4. **Load OpenFOAM Environment**: Sources the OpenFOAM environment script to set up necessary variables.
-5. **Copy Tutorial Files**: Copies the `motorBike` tutorial files from the OpenFOAM source code.
-6. **Clean Previous Results**: Cleans any previous simulation results.
-7. **Copy Geometry**: Copies the motorbike geometry file.
-8. **Define Surface Features**: Defines surface features for mesh generation.
-9. **Generate Mesh**: Generates the mesh for the simulation domain.
-10. **Decompose Mesh**: Decomposes the mesh for parallel processing.
-11. **Mesh Refinement**: Refines the mesh around the motorbike using `snappyHexMesh`.
-12. **Patch Summary**:  Generates a summary of boundary conditions.
-13. **Potential Flow Calculation**: Solves for the velocity potential.
-14. **Turbulent Flow Simulation**: Performs a steady-state simulation of turbulent flow using `simpleFoam`.
-15. **Reconstruct Results**: Reconstructs the simulation results from parallel execution.
+1. **Clone OpenFOAM:** If not already present, the script clones the OpenFOAM-11 source code from GitHub into the
+/nfs directory.
+2. **Create Working Directory:** A unique working directory is created within the shared /nfs/mnt/motorbike directory.
+3. **Fetch Apptainer Image:** The script pulls the pre-built OpenFOAM Apptainer image from a public Amazon ECR
+repository if it's not already available locally.
+4. **Copy Tutorial Files:** The necessary tutorial files, including the motorBike case setup, are copied from the
+OpenFOAM source code directory.
+5. **Clean Previous Results:** Any existing results from previous simulations are removed to ensure a clean starting
+point.
+6. **Copy Geometry:** The motorbike geometry file (motorBike.obj.gz) is copied into the constant/geometry directory
+of the case setup.
+7. **Generate Mesh:** The blockMesh utility is used to generate the initial mesh for the simulation domain.
+8. **Decompose Mesh:** The mesh is decomposed into multiple domains (-copyZero option) for parallel processing.
+9. **Mesh Refinement:** The snappyHexMesh utility refines the mesh around the motorbike geometry to capture finer details.
+The refinement process is executed in parallel using mpirun.
+10. **Remove Intermediate Files:** Intermediate mesh files (*level*) are removed to save storage space.
+11. **Renumber Mesh:** The mesh is renumbered (renumberMesh) to optimize parallel efficiency. This step is also performed
+in parallel.
+12. **Potential Flow Calculation:** The potentialFoam utility solves for the initial velocity potential field,
+initializing boundary conditions (-initialiseUBCs) for the subsequent simulation. The calculation is executed in parallel.
 
 ## HPC Application
 
@@ -31,5 +36,4 @@ This script utilizes the following HPC application:
 * **OpenFOAM:**: A widely-used open-source CFD software package for simulating fluid flow phenomena.
 
 The Apptainer image for OpenFOAM is pre-built with all necessary dependencies and configurations, simplifying
-execution and ensuring reproducibility across different HPC environments. For more details regarding the
-Apptainer image, check the [Dockerfile](./Dockerfile).
+execution and ensuring reproducibility across different HPC environments.

--- a/cfd-openfoam-motorbike/job-script.sh
+++ b/cfd-openfoam-motorbike/job-script.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
-#SBATCH --partition compute
-#SBATCH --nodes=2
-#SBATCH --ntasks=2
+#SBATCH --ntasks=8
 #SBATCH -J motorbike
-#SBATCH --output=/nfs/R-%x.%j.out
-#SBATCH --error=/nfs/R-%x.%j.err
-#SBATCH -t 1:00:00
+#SBATCH --output=/nfs/mnt/motorbike/R-%x.%j.out
+#SBATCH --error=/nfs/mnt/motorbike/R-%x.%j.err
+#SBATCH -t 8:00:00
 
 # clone OpenFOAM-11 if it is not available yet
 OPENFOAM_DIR=/nfs/OpenFOAM-11
@@ -19,12 +17,12 @@ else
 fi
 
 # create a working folder inside the shared directory
-WORK_DIR=/nfs/$SLURM_JOB_NAME-Job-$SLURM_JOB_ID
+WORK_DIR=/nfs/mnt/motorbike/$SLURM_JOB_NAME-Job-$SLURM_JOB_ID
 mkdir -p $WORK_DIR
 cd $WORK_DIR
 
 # path to the openfoam singularity image
-export APPTAINER_IMAGE=/nfs/openfoam11.sif
+export APPTAINER_IMAGE=/nfs/mnt/openfoam11.sif
 
 # download the openfoam v11 singularity image if it is not available yet
 if [[ ! -f $APPTAINER_IMAGE ]]
@@ -37,44 +35,22 @@ fi
 
 
 # copy motorBike folder
-cp -r $OPENFOAM_DIR/tutorials/incompressibleFluid/motorBike .
+cp -r $OPENFOAM_DIR/tutorials/incompressibleFluid/motorBike/motorBike .
 
-# enter motorBike folder
 cd motorBike
 
-# clear any previous execution
 apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE ./Allclean
 
-# copy motorBike geometry obj
 cp $OPENFOAM_DIR/tutorials/resources/geometry/motorBike.obj.gz constant/geometry/
 
-# define surface features inside the block mesh
-apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE surfaceFeatures
-
-# generate the first mesh
-# mesh the environment (block around the model)
 apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE blockMesh
 
-# decomposition of mesh and initial field data
-# according to the parameters in decomposeParDict located in the system
-# create 6 domains by default
 apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE decomposePar -copyZero
 
-# mesh the motorcicle
-# overwrite the new mesh files that are generated
-srun apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE snappyHexMesh -overwrite -parallel
+mpirun --np 8 apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE snappyHexMesh -overwrite -parallel
 
-# write field and boundary condition info for each patch
-srun apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE patchSummary -parallel
+find . -type f -iname "*level*" -exec rm {} \;
 
-# potential flow solver
-# solves the velocity potential to calculate the volumetric face-flux field
-srun apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE potentialFoam -parallel
+mpirun --np 8 apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE renumberMesh -overwrite
 
-# steady-state solver for incompressible turbutent flows
-srun apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE simpleFoam -parallel
-
-# after a case has been run in parallel
-# it can be reconstructed for post-processing
-apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE reconstructParMesh -constant
-apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE reconstructPar -latestTime
+mpirun --np 8 apptainer exec --bind $PWD:$HOME $APPTAINER_IMAGE potentialFoam -initialiseUBCs -parallel

--- a/cfd-openfoam-motorbike/metadata.yaml
+++ b/cfd-openfoam-motorbike/metadata.yaml
@@ -3,5 +3,5 @@ icon-url: https://upload.wikimedia.org/wikipedia/commons/4/48/OpenFOAM_logo.svg
 entrypoint: job-script.sh
 image-source: Dockerfile
 image-tags:
-- "1.0.0"
+- "2.0.0"
 - "latest"


### PR DESCRIPTION
#### What
This PR patches the motorbike job script in a way to fix the behaviour of the Apptainer image, as well as the commands necessary to run the motorbike tutorial in OpenFOAM 11.

#### Why
The Apptainer image was broken and the commands to execute the tutorial were wrong for OpenFOAM 11.